### PR TITLE
Fix to #98.

### DIFF
--- a/R/acf.R
+++ b/R/acf.R
@@ -63,7 +63,10 @@ ACF <- function(.data, ..., lag_max = NULL, demean = TRUE,
   compute_acf <- function(.data, value, ...){
     value <- enexpr(value)
     x <- eval_tidy(value, data = .data)
-    acf <- tail(as.numeric(acf(x, plot=FALSE, ...)$acf), -1)
+    acf <- as.numeric(acf(x, plot=FALSE, ...)$acf)
+    if(length(type) == 1 && type != "partial"){ # First indx already dropped
+      acf <- tail(acf, -1)
+    }
     tibble(lag = seq_along(acf), acf = acf)
   }
   value <- enexprs(...)

--- a/R/acf.R
+++ b/R/acf.R
@@ -60,11 +60,12 @@
 #' @export
 ACF <- function(.data, ..., lag_max = NULL, demean = TRUE,
                 type = c("correlation", "covariance", "partial")){
+  type <- match.arg(type)
   compute_acf <- function(.data, value, ...){
     value <- enexpr(value)
     x <- eval_tidy(value, data = .data)
     acf <- as.numeric(acf(x, plot=FALSE, ...)$acf)
-    if(type[1] != "partial"){ # First indx already dropped if partial
+    if(type != "partial"){ # First indx already dropped if partial
       acf <- tail(acf, -1)
     }
     tibble(lag = seq_along(acf), acf = acf)

--- a/R/acf.R
+++ b/R/acf.R
@@ -64,7 +64,7 @@ ACF <- function(.data, ..., lag_max = NULL, demean = TRUE,
     value <- enexpr(value)
     x <- eval_tidy(value, data = .data)
     acf <- as.numeric(acf(x, plot=FALSE, ...)$acf)
-    if(length(type) == 1 && type != "partial"){ # First indx already dropped
+    if(type[1] != "partial"){ # First indx already dropped if partial
       acf <- tail(acf, -1)
     }
     tibble(lag = seq_along(acf), acf = acf)

--- a/tests/testthat/test-cf.R
+++ b/tests/testthat/test-cf.R
@@ -39,6 +39,13 @@ test_that("PACF", {
     as.numeric(stats::pacf(dt$y, plot = FALSE)$acf)
   )
 
+  acf <- ACF(dt, y, type = "partial")
+  names(acf) <- c("lag", "pacf") # Overwrite names c("lag", "acf")
+  expect_identical(
+    cf,
+    acf
+  )
+
   p <- autoplot(cf)
   expect_identical(
     ggplot2::layer_data(p)$y,

--- a/tests/testthat/test-cf.R
+++ b/tests/testthat/test-cf.R
@@ -39,7 +39,7 @@ test_that("PACF", {
     as.numeric(stats::pacf(dt$y, plot = FALSE)$acf)
   )
 
-  acf <- ACF(dt, y, type = "partial")
+  acf <- ACF(dt, y, type = "part") # Testing also partial matching of "partial"
   names(acf) <- c("lag", "pacf") # Overwrite names c("lag", "acf")
   expect_identical(
     cf,
@@ -99,3 +99,4 @@ test_that("CCF", {
     "CCF currently only supports two columns"
   )
 })
+


### PR DESCRIPTION
Avoids dropping first index twice. stats::acf with type = "partial" drops first index.

Also added test case.