### PR TITLE
Optional arguments to seasonal::seas function are added

### DIFF
--- a/R/x11.R
+++ b/R/x11.R
@@ -30,7 +30,7 @@ train_X11 <- function(.data, formula, specials, type, ...){
   op <- switch(type, add = "+", mult = "*")
 
   fit <- seasonal::seas(y, x11 = "", x11.mode = type,
-                        transform.function = switch(type, add = "none", "log"))
+                        transform.function = switch(type, add = "none", "log"), ...)
 
   dcmp <- unclass(fit$data)
 


### PR DESCRIPTION
Example:

```r
x11_dcmp <- unemp %>% as_tsibble() %>% 
  model(x11 = feasts:::X11(unemp, type = "additive",
                           regression.variables = c("ls2009.11")))

dcmp <- seas(unemp, x11 = "", transform.function = "none",
             regression.variables = c("ls2009.11"))

x11_dcmp %>% components() %>% pull(seasonal) -> seasonal
seasonal - dcmp$data[, "seasonal"] # difference is non-zero in the initial implementation
```