### PR TITLE
Ensure `gg_season()` breaks are not out-of-bounds

### DIFF
--- a/R/graphics.R
+++ b/R/graphics.R
@@ -281,10 +281,15 @@ gg_season <- function(data, y = NULL, period = NULL, facet_period = NULL,
     ggplot2::labs(colour = NULL)
 
   if(num_ids <= max_col){
+    breaks <- if (num_ids <= max_col_discrete) {
+      seq_len(num_ids)
+    } else {
+      function(x) scales::oob_discard(scales::extended_breaks()(x), x)
+    }
     p <- p +
       ggplot2::scale_color_gradientn(
         colours = pal,
-        breaks = if (num_ids <= max_col_discrete) seq_len(num_ids) else ggplot2::waiver(),
+        breaks = breaks,
         labels = function(idx) levels(data$id)[idx]
       )
   }


### PR DESCRIPTION
Hi Mitchell,

For completion, I'll repeat that we've been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break feasts.

This PR updates a break calculation in `gg_seasion()`. Briefly, when `breaks = waiver()`, the automatic break calculation can include 0. In the `labels` function, subsetting using 0 gives an empty vector, which caused a mismatch between `length(breaks)` and `length(labels)`.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help feasts get out a fix if necessary.