### PR TITLE
Compatability with ggplot2

### DIFF
--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -189,7 +189,7 @@ test_that("gg_tsdisplay() plots", {
     list(x = "index", y = "value")
   )
 
-  p <- p + ggplot2::labs(x = "x", y = "y", title = "title")
+  p[[1]] <- p[[1]] + ggplot2::labs(x = "x", y = "y", title = "title")
 
   p_built <- ggplot2::ggplot_build(p[[1]])
 

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -267,11 +267,4 @@ test_that("gg_arma() plots", {
     ggplot2::layer_data(p, 4)$PANEL,
     factor(c(rep_along(ar_roots, 1), rep_along(ma_roots, 2)))
   )
-
-  p_built <- ggplot2::ggplot_build(p)
-
-  expect_equivalent(
-    p_built$plot$labels[c("x", "y")],
-    list(x = "Re(1/root)", y = "Im(1/root)")
-  )
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the agricolaeplotr package.
The long and short of it is that ggplot2 handles labels differently now than feast's test expect.
This PR removes a test that no longer holds and adapts a small label addition.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun

